### PR TITLE
Underline links in post and comment bodies

### DIFF
--- a/app/styles/meow-bootstrap.less
+++ b/app/styles/meow-bootstrap.less
@@ -292,6 +292,10 @@ img.avatar {
 .post-body, .comment-body {
     margin: 10px 0;
     min-height: 10px;
+    
+    a {
+      text-decoration: underline;
+    }
 
     p {
       word-wrap: break-word;


### PR DESCRIPTION
Current CSS style make visited link's text indistinguishable from all other text because of low contrast between them and background color (can be clearly seen in full size screenshots).
This issue can be solved in two ways: either by changing the link color (at least for visited one) or by turning on underlining (only for body links).
I prefer the last one.
# 
### Current style

![bnw_o](https://cloud.githubusercontent.com/assets/3206415/2838455/0077ff3a-d034-11e3-9196-c58962aef8d2.png)
### Proposed style

![bnw_n](https://cloud.githubusercontent.com/assets/3206415/2838467/4ba73746-d034-11e3-8a66-c5e53c84b053.png)
