### PR TITLE
Update URL for image thumbnail generator

### DIFF
--- a/app/scripts/config.coffee.example
+++ b/app/scripts/config.coffee.example
@@ -12,4 +12,4 @@ module.exports =
   BNW_WS_PROTOCOL: "wss"
 
   # Thumbify image service URL template.
-  THUMBIFY_URL: "https://uglyhx.appspot.com/thumb?img=<%= imageUrl %>"
+  THUMBIFY_URL: "https://bnw-thumb.r.worldssl.net/thumb?img=<%= imageUrl %>"


### PR DESCRIPTION
New one is more fault tolerant and doesn't fuck up GIFs and transparent PNGs
See https://bnw.im/p/G6Q9DJ
