### PR TITLE
popup comment near cursor not under cursor

### DIFF
--- a/app/scripts/meow_application.coffee
+++ b/app/scripts/meow_application.coffee
@@ -24,8 +24,7 @@ class MeowApplication extends Chaplin.Application
     # Register all routes and start routing
     @initRouter routes
 
-    utils.bindLinkOnHover()
-    utils.bindCommentOnHover()
+    utils.bindHoverEvents()
 
     # Freeze the application instance to prevent further changes
     Object.freeze? this

--- a/app/scripts/views/post.coffee
+++ b/app/scripts/views/post.coffee
@@ -83,6 +83,13 @@ module.exports = class PostView extends RefreshDateView
       @firstDiv.fadeOut("slow", => @dispose())
     setTimeout hide, 3000
 
+  updReplyLinks: ->
+    @model.replies.models.forEach (comment) ->
+      attributes = comment.getAttributes()
+      id = attributes.commentId
+      replyto = attributes.replyCommentId
+      utils.addReplyLink(id,replyto) if not replyto
+
   updComments: (data) ->
     @$(".post-comments-count").text(data.num)
 
@@ -92,6 +99,7 @@ module.exports = class PostView extends RefreshDateView
       # It's ok to rerender full post since .post-footer2 must be
       # completely rerendered.
       @render()
+      @updReplyLinks()
       return
 
     # Actually we could rerender on any small websocket event but


### PR DESCRIPTION
Previous version doesn't allow moving along reply links horizontally (why didn't i think of that?) because popup was under cursor and blocks other links, in this version it appears below cusror and whole logic 'add on mouseenter, remove on mouseleave' breaks down (there could be no mouseleave now and we still had to rid of popup). So I had to merge two functions because they have shared state and I changed logic a lot. Also I fixed issue with links to blacklisted users.